### PR TITLE
removed ";" after #include statement

### DIFF
--- a/FPS_GT511C3.cpp
+++ b/FPS_GT511C3.cpp
@@ -8,7 +8,7 @@
 	Modified for Particle Photon by Paul Kourany (peekay123), Oct 24, 2105
 */
 
-#include "FPS_GT511C3.h";
+#include "FPS_GT511C3.h"
 
 
 // returns the 12 bytes of the generated command packet


### PR DESCRIPTION
As reported by nbmoretto <a href="https://community.particle.io/t/gt-511c1r-fingerprint-scanner/16859#post_7">here</a>, the #include statement on line 11 should not have a semi-colon at the end.